### PR TITLE
Update getting started gebeurtenissen

### DIFF
--- a/modules/ROOT/attachments/openapi.yaml
+++ b/modules/ROOT/attachments/openapi.yaml
@@ -20,7 +20,7 @@ paths:
               $ref: '#/components/schemas/RegistreerAbonneeCommand'
       responses:
         '201':
-          description: Afnemer succesvol geregistreerd als abonnee van BRP API Gebeurtenissen.
+          description: Abonnee succesvol geregistreerd.
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -29,6 +29,8 @@ paths:
           $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+        '409':
+          $ref: '#/components/responses/409'
         '500':
           $ref: '#/components/responses/500'
       security:
@@ -74,14 +76,166 @@ paths:
           $ref: '#/components/responses/500'
       security:
         - clientCredentials: []
+  /abonnees/{abonneeNaam}/groepen:
+    parameters:
+      - $ref: '#/components/parameters/AbonneeNaamPathParameter'
+    post:
+      operationId: VoegGroepToe
+      summary: Voeg een groep toe aan een geregistreerde abonnee van BRP API Gebeurtenissen
+      tags:
+        - Abonnees
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoegGroepToeCommand'
+      responses:
+        '201':
+          description: Groep succesvol toegevoegd aan de abonnee van BRP API Gebeurtenissen.
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
+          $ref: '#/components/responses/409'
+        '500':
+          $ref: '#/components/responses/500'
+      security:
+        - clientCredentials: []
+    get:
+      operationId: RaadpleegGroepen
+      summary: Raadpleeg de groepen van de abonnee
+      tags:
+        - Abonnees
+      responses:
+        '200':
+          description: Lijst van groepen succesvol opgehaald.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RaadpleegGroepenResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+      security:
+        - clientCredentials: []
+  /abonnees/{abonneeNaam}/groepen/{groepNaam}:
+    parameters:
+      - $ref: '#/components/parameters/AbonneeNaamPathParameter'
+      - $ref: '#/components/parameters/GroepNaamPathParameter'
+    delete:
+      operationId: VerwijderGroep
+      summary: Verwijder een groep, inclusief alle abonnementen op de groep
+      tags:
+        - Abonnees
+      responses:
+        '204':
+          description: Groep succesvol verwijderd van de abonnee van BRP API Gebeurtenissen.
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+      security:
+        - clientCredentials: []
+  /abonnees/{abonneeNaam}/groepen/{groepNaam}/gebeurtenistypes:
+    parameters:
+      - $ref: '#/components/parameters/AbonneeNaamPathParameter'
+      - $ref: '#/components/parameters/GroepNaamPathParameter'
+    post:
+      operationId: VoegGebeurtenistypeToeAanGroep
+      summary: Voeg een gebeurtenistype toe aan een groep van een abonnee van BRP API Gebeurtenissen
+      tags:
+        - Abonnees
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoegGebeurtenistypeToeCommand'
+      responses:
+        '201':
+          description: Gebeurtenistype succesvol toegevoegd aan de groep.
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
+          $ref: '#/components/responses/409'
+        '500':
+          $ref: '#/components/responses/500'
+      security:
+        - clientCredentials: []
+    get:
+      operationId: RaadpleegGebeurtenistypes
+      summary: Raadpleeg de gebeurtenistypes in de groep
+      tags:
+        - Abonnees
+      responses:
+        '200':
+          description: Lijst van gebeurtenistypes succesvol opgehaald.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RaadpleegGebeurtenistypesResponse'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+      security:
+        - clientCredentials: []
+  /abonnees/{abonneeNaam}/groepen/{groepNaam}/gebeurtenistypes/{gebeurtenistype}:
+    parameters:
+      - $ref: '#/components/parameters/AbonneeNaamPathParameter'
+      - $ref: '#/components/parameters/GroepNaamPathParameter'
+      - $ref: '#/components/parameters/GebeurtenistypePathParameter'
+    delete:
+      operationId: VerwijderGebeurtenistype
+      summary: Verwijder een gebeurtenistype uit een groep
+      tags:
+        - Abonnees
+      responses:
+        '204':
+          description: Gebeurtenistype succesvol verwijderd uit de groep.
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+      security:
+        - clientCredentials: []
   /abonnees/{abonneeNaam}/abonnementen:
     parameters:
       - $ref: '#/components/parameters/AbonneeNaamPathParameter'
     post:
-      operationId: VoeruitAbonnementenCommand
-      summary: Abonnementen commands uitvoeren voor een bestaande abonnee, zoals het abonneren op gebeurtenis types van een persoon of opzeggen van abonnementen
+      operationId: VoerUitAbonnementenCommand
+      summary: Opdrachten voor het abonneren op gebeurtenissen. Hiermee kan je een abonnement nemen of een abonnement opzeggen.
       tags:
-        - Abonnees
+        - Abonnementen
       requestBody:
         required: true
         content:
@@ -101,6 +255,8 @@ paths:
           $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+        '409':
+          $ref: '#/components/responses/409'
         '500':
           $ref: '#/components/responses/500'
       security:
@@ -109,7 +265,7 @@ paths:
       operationId: RaadpleegAbonnementen
       summary: Raadpleeg de lijst van abonnementen van een abonnee
       tags:
-        - Abonnees
+        - Abonnementen
       parameters:
         - $ref: '#/components/parameters/CursorQueryParameter'
           description: Gebruik dit voor paginering. Vul hier de id van het laatst ontvangen abonnement op om de hieropvolgende abonnementen te ontvangen.
@@ -144,16 +300,10 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/AbonneeNaam'
-        - name: cursor
-          in: query
-          required: false
-          schema:
-            $ref: '#/components/schemas/schemas-Cursor'
-        - name: limit
-          in: query
-          required: false
-          schema:
-            $ref: '#/components/schemas/schemas-Limit'
+        - $ref: '#/components/parameters/CursorQueryParameter'
+          description: Geef de id van de laatst ontvangen gebeurtenis op om de volgende ongelezen gebeurtenissen te ontvangen. Cursor moet een geldige id van een gebeurtenis zijn.
+        - $ref: '#/components/parameters/LimitQueryParameter'
+          description: Aantal te retourneren gebeurtenissen
       responses:
         '200':
           description: Het gevraagde aantal gebeurtenissen is succesvol opgehaald en geleverd
@@ -174,18 +324,27 @@ paths:
       security:
         - clientCredentials: []
 components:
+  securitySchemes:
+    clientCredentials:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://probeerbrpapi.rvig.nl/realms/brp-api/protocol/openid-connect/token
+          scopes: {}
   schemas:
     AbonneeNaam:
       type: string
-      pattern: ^(?!.*--)[a-z][a-z-]{0,8}[a-z]$
+      minLength: 2
+      maxLength: 64
+      pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
       description: |
         De naam van de abonnee. 
-        Moet voldoen aan de volgende regels:
-          - Begint en eindigt met een kleine letter
-          - Bevat minimaal 2 en maximaal 10 tekens
-          - Bevat alleen kleine letters (a-z) en koppeltekens (-)
-          - Bevat geen dubbele koppeltekens (--)
-      example: abonnee
+        Moet voldoen aan de volgende criteria:
+          - bevat alleen kleine letters (a-z), cijfers (0-9) en koppeltekens (-)
+          - bevat geen dubbele koppeltekens achter elkaar (--)
+          - bevat minimaal 2 en maximaal 64 tekens
+          - begint en eindigt niet met een koppelteken (-)
+      example: abonnee-voorbeeld-001
     Abonnee:
       type: object
       properties:
@@ -234,10 +393,10 @@ components:
     RegistreerAbonneeCommand:
       type: object
       properties:
-        abonneeNaam:
+        naam:
           $ref: '#/components/schemas/AbonneeNaam'
       required:
-        - abonneeNaam
+        - naam
     InvalidParam:
       type: object
       description: Details over fouten in opgegeven parameters
@@ -245,7 +404,7 @@ components:
         type:
           type: string
           format: uri
-          example: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+          example: https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error
         name:
           description: Naam van de parameter
           type: string
@@ -272,6 +431,66 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/InvalidParam'
+    GroepNaam:
+      type: string
+      minLength: 2
+      maxLength: 64
+      pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
+      description: |
+        De naam van de groep. 
+        Moet voldoen aan de volgende criteria:
+          - bevat alleen kleine letters (a-z), cijfers (0-9) en koppeltekens (-)
+          - bevat geen dubbele koppeltekens achter elkaar (--)
+          - bevat minimaal 2 en maximaal 64 tekens
+          - begint en eindigt niet met een koppelteken (-)
+      example: groep-voorbeeld-001
+    Groep:
+      type: object
+      properties:
+        naam:
+          $ref: '#/components/schemas/GroepNaam'
+          description: De naam van de groep
+    RaadpleegGroepenResponse:
+      type: object
+      properties:
+        groepen:
+          type: array
+          items:
+            $ref: '#/components/schemas/Groep'
+          description: Lijst van groepen van de abonnee
+      required:
+        - groepen
+    VoegGroepToeCommand:
+      type: object
+      properties:
+        naam:
+          $ref: '#/components/schemas/GroepNaam'
+      required:
+        - naam
+    GebeurtenisTypeVanPersoonEnum:
+      type: string
+      pattern: ^[a-z/-/.]{1,50}$
+      enum:
+        - nl.brp.verhuisd.intergemeentelijk
+        - nl.brp.verhuisd.naar-buitenland
+        - nl.brp.overleden
+    RaadpleegGebeurtenistypesResponse:
+      type: object
+      properties:
+        gebeurtenistypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/GebeurtenisTypeVanPersoonEnum'
+          description: Lijst van gebeurtenistypes in de groep
+      required:
+        - gebeurtenistypes
+    VoegGebeurtenistypeToeCommand:
+      type: object
+      properties:
+        gebeurtenistype:
+          $ref: '#/components/schemas/GebeurtenisTypeVanPersoonEnum'
+      required:
+        - gebeurtenistype
     Cursor:
       type: string
       format: uuid
@@ -281,6 +500,12 @@ components:
       minimum: 1
       maximum: 10
       description: Het aantal resources dat in één response wordt teruggegeven.
+    Burgerservicenummer:
+      type: string
+      title: Burgerservicenummer
+      description: |
+        Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer.
+      pattern: ^[0-9]{9}$
     Abonnement:
       type: object
       properties:
@@ -288,43 +513,16 @@ components:
           type: string
           format: uuid
           description: Unieke identifier van het abonnement
-        type:
-          type: string
+        groep:
+          $ref: '#/components/schemas/GroepNaam'
+          description: De groep met gebeurtenistypes waarop de abonnee een abonnement heeft voor de persoon
+        burgerservicenummer:
+          $ref: '#/components/schemas/Burgerservicenummer'
+          description: Het burgerservicenummer (BSN) van de persoon waarvoor de abonnee gebeurtenissen ontvangt
       required:
         - id
-        - type
-      discriminator:
-        propertyName: type
-        mapping:
-          AbonnementOpGebeurtenisTypeVanPersoon: '#/components/schemas/AbonnementOpGebeurtenisTypeVanPersoon'
-    GebeurtenisTypeVanPersoonEnum:
-      type: string
-      pattern: ^[a-z/-/.]{1,50}$
-      enum:
-        - nl.brp.verhuisd.intergemeentelijk
-        - nl.brp.verhuisd.naar-buitenland
-        - nl.brp.overleden
-    Burgerservicenummer:
-      type: string
-      title: Burgerservicenummer
-      description: |
-        Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer.
-      pattern: ^[0-9]{9}$
-    AbonnementOpGebeurtenisTypeVanPersoon:
-      allOf:
-        - $ref: '#/components/schemas/Abonnement'
-        - type: object
-          properties:
-            gebeurtenisType:
-              $ref: '#/components/schemas/GebeurtenisTypeVanPersoonEnum'
-              description: Het gebeurtenistype waarop de abonnee zich heeft geabonneerd
-            burgerservicenummer:
-              $ref: '#/components/schemas/Burgerservicenummer'
-              description: Het burgerservicenummer (BSN) van de persoon waarvoor de abonnee gebeurtenissen van het opgegeven type ontvangt
-          required:
-            - id
-            - gebeurtenisType
-            - burgerservicenummer
+        - groep
+        - burgerservicenummer
     RaadpleegAbonnementenResponse:
       type: object
       properties:
@@ -345,58 +543,37 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          AbonneerOpGebeurtenisTypeVanPersoon: '#/components/schemas/AbonneerOpGebeurtenisTypeVanPersoonCommand'
-          ZegOpAbonnementOpGebeurtenisTypeVanPersoon: '#/components/schemas/ZegOpAbonnementOpGebeurtenisTypeVanPersoonCommand'
-          ZegOpAbonnementenOpPersoon: '#/components/schemas/ZegOpAbonnementenOpPersoonCommand'
-    AbonneerOpGebeurtenisTypeVanPersoonCommand:
+          AbonneerPersoonOpGroep: '#/components/schemas/AbonneerPersoonOpGroepCommand'
+          ZegOpAbonnementVanPersoonOpGroep: '#/components/schemas/ZegOpAbonnementVanPersoonOpGroepCommand'
+    AbonneerPersoonOpGroepCommand:
       allOf:
         - $ref: '#/components/schemas/AbonnementenCommand'
         - type: object
           properties:
-            gebeurtenisType:
-              $ref: '#/components/schemas/GebeurtenisTypeVanPersoonEnum'
-              description: Het gebeurtenistype waarop de abonnee zich wil abonneren
+            groep:
+              $ref: '#/components/schemas/GroepNaam'
+              description: De groep waarop de abonnee de persoon wil abonneren
             burgerservicenummer:
               $ref: '#/components/schemas/Burgerservicenummer'
-              description: Het burgerservicenummer (BSN) van de persoon waarvoor de abonnee gebeurtenissen van het opgegeven type wil ontvangen
+              description: Het burgerservicenummer (BSN) van de persoon waarvoor de abonnee gebeurtenissen wil ontvangen
           required:
-            - gebeurtenisType
+            - groep
             - burgerservicenummer
-    ZegOpAbonnementOpGebeurtenisTypeVanPersoonCommand:
+    ZegOpAbonnementVanPersoonOpGroepCommand:
       allOf:
         - $ref: '#/components/schemas/AbonnementenCommand'
         - type: object
-          description: Beëindigen van een 'gebeurtenis type van persoon' abonnement van een abonnee.
+          description: Beëindigen van een abonnement voor een persoon voor een groep
           properties:
-            gebeurtenisType:
-              $ref: '#/components/schemas/GebeurtenisTypeVanPersoonEnum'
+            groep:
+              $ref: '#/components/schemas/GroepNaam'
+              description: De groep waarop de abonnee de persoon wil abonneren
             burgerservicenummer:
               $ref: '#/components/schemas/Burgerservicenummer'
+              description: Het burgerservicenummer (BSN) van de persoon waarvoor de abonnee de gebeurtenissen niet meer wil ontvangen
           required:
-            - gebeurtenisType
+            - groep
             - burgerservicenummer
-    ZegOpAbonnementenOpPersoonCommand:
-      allOf:
-        - $ref: '#/components/schemas/AbonnementenCommand'
-        - type: object
-          description: Beëindigen van alle abonnementen op een persoon van een abonnee.
-          properties:
-            burgerservicenummer:
-              $ref: '#/components/schemas/Burgerservicenummer'
-              description: Het burgerservicenummer (BSN) van de persoon van wie de abonnee geen gebeurtenissen meer wil ontvangen
-          required:
-            - burgerservicenummer
-    schemas-Cursor:
-      description: Geef de id van de laatst ontvangen gebeurtenis op om de volgende ongelezen gebeurtenissen te ontvangen. Cursor moet een geldige id van een gebeurtenis zijn.
-      type: string
-      format: uuid
-      example: 123e4567-e89b-12d3-a456-426614174000
-    schemas-Limit:
-      description: Aantal te retourneren gebeurtenissen
-      type: integer
-      minimum: 1
-      maximum: 10
-      example: 3
     Gebeurtenis:
       type: object
       properties:
@@ -614,7 +791,7 @@ components:
           schema:
             $ref: '#/components/schemas/BadRequestFoutbericht'
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+            type: https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request
             title: Ten minste één parameter moet worden opgegeven.
             status: 400
             detail: The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.
@@ -632,7 +809,7 @@ components:
           schema:
             $ref: '#/components/schemas/Foutbericht'
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+            type: https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized
             title: Niet correct geauthenticeerd.
             status: 401
             detail: The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.
@@ -645,7 +822,7 @@ components:
           schema:
             $ref: '#/components/schemas/Foutbericht'
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+            type: https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden
             title: U bent niet geautoriseerd voor deze operatie.
             status: 403
             detail: The server understood the request, but is refusing to fulfill it.
@@ -658,12 +835,25 @@ components:
           schema:
             $ref: '#/components/schemas/Foutbericht'
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5
+            type: https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found
             title: Opgevraagde resource bestaat niet.
             status: 404
             detail: The server has not found anything matching the Request-URI.
             instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
             code: notFound
+    '409':
+      description: Conflict
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict
+            title: Conflict
+            status: 409
+            detail: The request could not be completed due to a conflict with the current state of the resource
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: conflict
     '500':
       description: Internal Server Error
       content:
@@ -671,7 +861,7 @@ components:
           schema:
             $ref: '#/components/schemas/Foutbericht'
           example:
-            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+            type: https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error
             title: Interne server fout.
             status: 500
             detail: The server encountered an unexpected condition which prevented it from fulfilling the request.
@@ -685,6 +875,19 @@ components:
       schema:
         $ref: '#/components/schemas/AbonneeNaam'
         description: De naam van de abonnee
+    GroepNaamPathParameter:
+      name: groepNaam
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/GroepNaam'
+        description: De naam van de abonnee
+    GebeurtenistypePathParameter:
+      name: gebeurtenistype
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/GebeurtenisTypeVanPersoonEnum'
     CursorQueryParameter:
       name: cursor
       in: query

--- a/modules/ROOT/pages/gebeurtenissen-api-proberen.adoc
+++ b/modules/ROOT/pages/gebeurtenissen-api-proberen.adoc
@@ -9,7 +9,7 @@ Bijvoorbeeld wanneer een minderjarige die in behandeling is bij Jeugdzorg naar e
 
 Vaak is er bij een gebeurtenis ook iets gewijzigd in de gegevens van de persoon. Bijvoorbeeld bij de gebeurtenis "verhuisd.intergemeentelijk" is het adres van de persoon gewijzigd en ook de gemeente van inschrijving. Dit kan je dan opvragen in de BRP personen API.
 
-In de API noemen we het volgen van een persoon op een soort gebeurtenis een "abonnement". Een abonnement is dus de combinatie van een persoon (burgerservicenummer) en het type gebeurtenis waarin je geïnteresseerd bent.
+In de API noemen we het volgen van een persoon op een soort gebeurtenis een "abonnement".
 
 In de API kun je op een zelf te kiezen moment opvragen of er gebeurtenissen hebben plaatsgevonden op je abonnementen. Je mag hier zelf de frequentie en het moment voor kiezen, bijvoorbeeld één keer per dag of elk uur.
 
@@ -17,6 +17,9 @@ In de API kunnen abonnementen worden beheerd en gebeurtenissen worden gevraagd p
 Bijvoorbeeld Jeugdzorg zal alleen doelbinding hebben om minderjarige clienten en hun ouders te volgen. Sociale Zaken zal alleen clienten die een uitkering hebben volgen.
 
 In de API noemen we een dienst of taakapplicatie die abonnementen zet en gebeurtenissen vraagt een "abonnee".
+Een abonnee zal normaal gesproken personen abonneren op een vaste set aan gebeurtenistypes. Zo'n set gebeurtenistypes noemen we in de API een "groep".
+Voor een abonnee kunnen meerdere groepen worden gemaakt, wanneer verschillende personen op een andere combinatie van gebeurtenistypes moeten worden gevolgd, omdat ze een andere rol hebben in het proces. Denk bijvoorbeeld voor leerplicht aan een groep "leerplichtige" en een groep "ouder". Of bijvoorbeeld voor sociale zaken aan een groep "uitkeringsgerechtigde" en een groep "partner".
+Een abonnee kan vervolgens een persoon abonneren op een groep, waarmee er een abonnement wordt gezet voor de persoon op alle gebeurtenistypes in de groep.
 
 De abonnee geeft bij het vragen van gebeurtenissen de laatste ontvangen (verwerkte) gebeurtenis op om alleen gebeurtenissen te ontvangen die de abonnee nog niet gelezen heeft. Hier is de abonnee zelf in controle wanneer en welke gebeurtenissen worden ontvangen. De abonnee is er daarmee ook verantwoordelijk voor om te zorgen dat deze alle gebeurtenissen ontvangt en correct verwerkt.
 
@@ -24,8 +27,8 @@ De abonnee geeft bij het vragen van gebeurtenissen de laatste ontvangen (verwerk
 
 De API is ontworpen voor het doorlopen van de volgende stappen:
 
-. de gemeente (als afnemer) meldt een taakapplicatie aan als abonnee. Zie <<Registreer een abonnee>>.
-. de abonnee neemt abonnementen op clienten voor de gebeurtenistypes waar ze doelbinding voor hebben. Zie <<Abonneer op een gebeurtenistype van een persoon>>.
+. de gemeente (als afnemer) meldt een taakapplicatie aan als abonnee, Vervolgens voegt de gemeente daar een of meerdere groepen aan toe en voegt per groep de gebeurtenistypes toe waar de abonnee voor deze groep doelbinding voor heeft. Zie <<Registreer een abonnee>>.
+. de abonnee neemt abonnementen op clienten voor een groep. Zie <<Abonneer op een persoon>>.
 . de abonnee vraagt (met een bepaalde frequentie) ongelezen gebeurtenissen op. Zie <<Vraag gebeurtenissen>>.
 . de abonnee herhaalt de vorige stap tot alle gebeurtenissen gelezen zijn.
 . de abonnee verwerkt de gebeurtenissen en vraagt desgewenst de gewijzigde gegevens van de persoon op in de BRP API /personen of /verblijfplaatshistorie.
@@ -67,7 +70,7 @@ Om de API te kunnen gebruiken moet je een OAuth token meesturen met elk request.
 
 Om op de probeeromgeving een token aan te vragen stuur je een request zoals deze:
 ```
-curl --location -–request POST 'https://probeerbrpapi.rvig.nl/realms/brp-api/protocol/openid-connect/token' \
+curl --location 'https://probeerbrpapi.rvig.nl/realms/brp-api/protocol/openid-connect/token' \
 --header 'Content-Type: application/x-www-form-urlencoded' \
 --data-urlencode 'grant_type=client_credentials' \
 --data-urlencode 'client_id={{client-id die je van ons ontvangt als je toegang hebt aangevraagd}}' \
@@ -94,7 +97,7 @@ Het token dat je moet meesturen met elk request staat in het antwoord in "access
 
 Voor een applicatie de gebeurtenissen API kan gebruiken voor het zetten van abonnementen en opvragen van gebeurtenissen, moet je de deze als abonnee registreren.
 
-Om op de probeeromgeving een abonnee te registreren, stuur je een request zoals deze:
+Om op de probeeromgeving een abonnee te registreren stuur je een request zoals deze:
 ```
 curl --location 'https://probeerbrpapi.rvig.nl/api/brp/abonnees' \
 --header 'Content-Type: application/json' \
@@ -107,7 +110,41 @@ curl --location 'https://probeerbrpapi.rvig.nl/api/brp/abonnees' \
 * Vervang hierin {{token}} met het access token dat je eerder hebt gevraagd.
 * Vervang hierin {{naam van de abonnee}} met de naam van de abonnee (de naam van de dienst of taakapplicatie).
 
-== Abonneer op een gebeurtenistype van een persoon
+Voor de abonnee een abonnement kan nemen, moet je een groep toevoegen aan de abonnee.
+Om aan de abonnee een groep toe te voegen stuur je een request zoals deze:
+```
+curl --location 'https://probeerbrpapi.rvig.nl/api/brp/abonnees/{{naam van de abonnee}}/groepen' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: {{token}}' \
+--data '{
+  "naam": "{{naam van de groep}}"
+}'
+```
+
+* Vervang hierin {{token}} met het access token dat je eerder hebt gevraagd.
+* Vervang hierin {{naam van de abonnee}} met de naam van de abonnee (de naam van de dienst of taakapplicatie).
+* Vervang hierin {{naam van de groep}} met de naam die je aan de groep wilt geven.
+
+Voeg vervolgens de gebeurtenistypes toe aan de groep die de abonnee wil en mag ontvangen voor deze groep.
+Om aan de groep een gebeurtenistype toe te voegen stuur je een request zoals deze:
+```
+curl --location 'https://probeerbrpapi.rvig.nl/api/brp/brp/abonnees/{{naam van de abonnee}}/groepen/{{naam van de groep}}/gebeurtenistypes' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: {{token}}' \
+--data '{
+  "gebeurtenistype": "{{gebeurtenistype}}"
+}'
+```
+
+* Vervang hierin {{token}} met het access token dat je eerder hebt gevraagd.
+* Vervang hierin {{naam van de abonnee}} met de naam van de abonnee (de naam van de dienst of taakapplicatie).
+* Vervang hierin {{naam van de groep}} met de naam van de groep die je eerder hebt toegevoegd.
+* Vervang hierin {{gebeurtenistype}} met het gebeurtenistype dat je aan de groep wilt toevoegen. Op dit moment zijn er drie typen gebeurtenis waarop je kunt abonneren:
+** nl.brp.verhuisd.intergemeentelijk
+** nl.brp.verhuisd.naar-buitenland
+** nl.brp.overleden
+
+== Abonneer op een persoon
 
 Om op de probeeromgeving een abonnement te nemen, stuur je een request zoals deze:
 ```
@@ -115,19 +152,16 @@ curl --location 'https://probeerbrpapi.rvig.nl/api/brp/abonnees/{{naam van de ab
 --header 'Content-Type: application/json' \
 --header 'Authorization: {{token}}' \
 --data '{
-  "type": "AbonneerOpGebeurtenisTypeVanPersoon",
-  "gebeurtenisType": "{{gebeurtenis type}}",
+  "type": "AbonneerPersoonOpGroep",
+  "groep": "{{naam van de groep}}",
   "burgerservicenummer": "{{burgerservicenummer}}"
 }'
 ```
 
 * Vervang hierin {{naam van de abonnee}} met de naam van de abonnee (de naam van de dienst of taakapplicatie).
 * Vervang hierin {{token}} met het access token dat je eerder hebt gevraagd.
+* Vervang hierin {{naam van de groep}} met de naam van de groep die je eerder hebt toegevoegd.
 * Vervang hierin {{burgerservicenummer}}. Je hebt van ons een lijst met burgerservicenummers ontvangen die je hiervoor kunt gebruiken.
-* Vervang hierin {{gebeurtenis type}} met het type gebeurtenis dat je wilt ontvangen. Op dit moment zijn er drie typen gebeurtenis waarop je kunt abonneren:
-** nl.brp.verhuisd.intergemeentelijk
-** nl.brp.verhuisd.naar-buitenland
-** nl.brp.overleden
 
 == Vraag gebeurtenissen
 
@@ -150,27 +184,16 @@ curl --location 'https://probeerbrpapi.rvig.nl/api/brp/abonnees/{{naam van de ab
 --header 'Content-Type: application/json' \
 --header 'Authorization: {{token}}' \
 --data '{
-  "type": "ZegOpAbonnementOpGebeurtenisTypeVanPersoon",
-  "gebeurtenisType": "{{gebeurtenis type}}",
-  "burgerservicenummer": "{{burgerservicenummer}}"
-}'
-```
-
-Of om alle abonnementen van een persoon te beëindigen, stuur je een request zoals deze:
-```
-curl --location 'https://probeerbrpapi.rvig.nl/api/brp/abonnees/{{naam van de abonnee}}/abonnementen' \
---header 'Content-Type: application/json' \
---header 'Authorization: {{token}}' \
---data '{
-  "type": "ZegOpAbonnementenOpPersoon",
+  "type": "AbonneerPersoonOpGroep",
+  "groep": "{{naam van de groep}}",
   "burgerservicenummer": "{{burgerservicenummer}}"
 }'
 ```
 
 * Vervang hierin {{naam van de abonnee}} met de naam van de abonnee (de naam van de dienst of taakapplicatie).
 * Vervang hierin {{token}} met het access token dat je eerder hebt gevraagd.
-* Vervang hierin {{burgerservicenummer}} van de persoon waar je het abonnement van wilt beëindigen. Je hebt van ons een lijst met burgerservicenummers ontvangen die je hiervoor kunt gebruiken.
-* Vervang hierin {{gebeurtenis type}} met het type gebeurtenis dat je wilt beëindigen voor de persoon.
+* Vervang hierin {{naam van de groep}} met de naam van de groep waar je eerder een abonnement op genomen hebt.
+* Vervang hierin {{burgerservicenummer}} met het burgerservicenummer waar je eerder een abonnement op genomen hebt.
 
 Het beëindigen van een abonnement is een POST request naar dezelfde url die je gebruikt voor het nemen van een abonnement. De waarde in de body bij "type" bepaalt wat de API hier doet.
 
@@ -178,9 +201,9 @@ Het beëindigen van een abonnement is een POST request naar dezelfde url die je 
 
 In de probeeromgeving is het mogelijk om wijzigingen te sturen, zodat je zelf kan bepalen welke gebeurtenissen je krijgt in je tests.
 
-dit doet twee dingen:
-Er ontstaat een nieuwe gebeurtenis, die je kunt opvragen met de gebeurtenissen API
-De gegevens wijzigen in de BRP, zodat je in de personen API de gewijzigde gegevens kunt raadplegen
+Dit doet twee dingen:
+* Er ontstaat een nieuwe gebeurtenis, die je kunt opvragen met de gebeurtenissen API.
+* De gegevens wijzigen in de BRP, zodat je in de personen API de gewijzigde gegevens kunt raadplegen.
 
 We kennen nu drie soorten wijzigingen:
 
@@ -253,3 +276,41 @@ curl --location 'https://probeerbrpapi.rvig.nl/api/brp/personen/aangiftes' \
 * Vervang hierin {{datum}} met de datum dat de persoon is overleden. Dit is een datum in formaat yyyy-mm-dd (bijvoorbeeld "2026-04-09").
 * Vervang hierin {{plaats}} met de gemeentecode in de https://publicaties.rvig.nl/media/13284/download[gemeententabel] of de plaatsnaam (bijvoorbeeld "London" of "Berlin") wanneer het een buitenlandse verblijfplaats betreft.
 * Vervang hierin {{landcode}} met een code die voorkomt in de https://publicaties.rvig.nl/media/13286/download[landentabel]. Wanneer de persoon in Nederland is overleden, vul je "6030". Wanneer je wilt opgeven dat de persoon is vertrokken met onbekende verblijfplaats, dan vul je alleen bij "landCode" de waarde "0000" en laat je "regel1", "regel2" en "regel3" weg uit het request.
+
+== Raadpleegen
+
+Het is mogelijk om alles wat je maakt ook te raadplegen. Gebruik hiervoor de "GET" operaties met method "GET" (zie de xref:gebeurtenissen/specificatie.adoc[API specificaties]).
+
+Bijvoorbeeld om op de probeeromgeving de gebeurtenistypes in een groep te raadplegen, stuur je een request zoals deze:
+```
+curl --location 'https://probeerbrpapi.rvig.nl/api/brp/abonnees/{{naam van de abonnee}}/groepen/{{naam van de groep}}/gebeurtenistypes' \
+--header 'Authorization: {{token}}'
+```
+
+* Vervang hierin {{naam van de abonnee}} met de naam van de abonnee (de naam van de dienst of taakapplicatie).
+* Vervang hierin {{naam van de groep}} met de naam van de groep die je eerder hebt toegevoegd.
+* Vervang hierin {{token}} met het access token dat je eerder hebt gevraagd.
+
+Om op de probeeromgeving alle actieve abonnementen te raadplegen, stuur je een request zoals deze:
+```
+curl --location 'https://probeerbrpapi.rvig.nl/api/brp/abonnees/{{naam van de abonnee}}/abonnementen' \
+--header 'Authorization: {{token}}'
+```
+
+== Wis de abonnee en bijbehorende groep(en) en abonnement(en)
+
+Het mogelijk om alles wat je maakt te wissen. Gebruik hiervoor de "DELETE" operaties (zie de xref:gebeurtenissen/specificatie.adoc[API specificaties]).
+
+Wanneer je iets wist, worden ook alle onderliggende zaken direct gewist:
+* Als je een gebeurtenistype uit een groep verwijdert, dan zullen ook de bestaande abonnementen op de groep geen gebeurtenissen van dit type meer ontvangen.
+* Als je een groep verwijdert, dat verwijder je automatisch ook de gebeurtenistypes die in de groep zitten en beëindig je alle abonnementen op deze groep.
+* Als je een abonnee deregistreert, dan verwijder je automatisch ook de bijbehorende groepen en gebeurtenistypes en beëindig je alle abonnementen van deze abonnee.
+
+Om op de probeeromgeving een abonnee en alle onderliggende groepen en abonnementen te verwijderen, stuur je een request zoals deze:
+```
+curl --location --request DELETE 'https://probeerbrpapi.rvig.nl/api/brp/abonnees/{{naam van de abonnee}}' \
+--header 'Authorization: {{token}}'
+```
+
+* Vervang hierin {{naam van de abonnee}} met de naam van de abonnee die je wilt deregistreren.
+* Vervang hierin {{token}} met het access token dat je eerder hebt gevraagd.


### PR DESCRIPTION
Fixes https://github.com/BRP-API/brp-api-gebeurtenissen/issues/238

beschrijft werking van beheren van abonnees, waarbij toevoegen van groepen aan abonnees en toevoegen van gebeurtenissen aan groepen aan de beschrijving is toegevoegd

ook beschrijving van abonneren is gewijzigd, omdat op groep wordt geabonneerd in plaats van op gebeurtenistype

ook beschrijving van raadplegen en verwijderen/deregistreren (met cascading delete) toegevoegd